### PR TITLE
Correct Include Order in ngx_http_auth_totp.c to Follow NGINX Development Principles

### DIFF
--- a/ngx_http_auth_totp.c
+++ b/ngx_http_auth_totp.c
@@ -1,9 +1,9 @@
-#include <stdint.h>
-#include <time.h>
-
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
+
+#include <stdint.h>
+#include <time.h>
 
 #include <openssl/hmac.h>
 


### PR DESCRIPTION
This pull request fixes a compilation issue in the `ngx_http_auth_totp` module related to the incomplete type definition of `struct in6_pktinfo`. The issue occurred due to the incorrect order of header file inclusions in `ngx_http_auth_totp.c`. For example, failed to compile like this:

```
gcc -c -fPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer  -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fPIC -I/usr/include/quictls -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/mail -I src/stream \
        -o objs/ngx_http_auth_totp_module_modules.o \
        objs/ngx_http_auth_totp_module_modules.c
In file included from src/event/ngx_event.h:526,
                 from src/http/ngx_http_upstream.h:14,
                 from src/http/ngx_http.h:36,
                 from nginx-http-auth-totp-1.0.0/ngx_http_auth_totp.c:6:
src/event/ngx_event_udp.h:46:27: error: field ‘pkt6’ has incomplete type
   46 |     struct in6_pktinfo    pkt6;
      |                           ^~~~
make[1]: *** [objs/Makefile:1875: objs/addon/nginx-http-auth-totp-1.0.0/ngx_http_auth_totp.o] Error 1
```

This change ensures that the necessary types and macros are defined correctly by the NGINX core headers before any other includes that might depend on them, resolving the compilation error.

#### Background:

According to NGINX developer principles, core NGINX headers (`<ngx_config.h>` and `<ngx_core.h>`) should be included at the very top of source files, even before standard library headers. This ordering prevents incomplete type issues and ensures proper macro definitions for building modules in the NGINX ecosystem.

#### Impact:

- Fixes compilation errors related to incomplete type definitions (e.g., `struct in6_pktinfo`).
- Aligns the module code with NGINX development guidelines, ensuring better compatibility and maintainability.
